### PR TITLE
feat(perf): crawling and plotting perf

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -20,10 +20,13 @@ def index():
     nations = engine.gatherData()
     totalGraphRaw = engine.processData(nations,datetime.now().strftime(engine.DATE_FORMAT), days = days)
     deathsGraphRaw = engine.processData(nations,datetime.now().strftime(engine.DATE_FORMAT), isDeaths=True , days = days)
+    deathsPopGraphRaw = engine.processData(nations, datetime.now().strftime(engine.DATE_FORMAT), isDeaths=True, isPopulation=True, days=days)
 
     return render_template('index.html',
                            countries=totalGraphRaw['countries'].decode('ascii') ,
                            delays=totalGraphRaw['delays'].decode('ascii'),
                            deathsCountries=deathsGraphRaw['countries'].decode('ascii'),
                            deathsDelays=deathsGraphRaw['delays'].decode('ascii'),
+                           deathsPopCountries=deathsPopGraphRaw['countries'].decode('ascii'),
+                           deathsPopDelays=deathsPopGraphRaw['delays'].decode('ascii'),
                            )

--- a/app/routes.py
+++ b/app/routes.py
@@ -17,8 +17,9 @@ def index():
         days = 50
 
     # generate graphs
-    totalGraphRaw = engine.processData(datetime.now().strftime(engine.DATE_FORMAT), days = days)
-    deathsGraphRaw = engine.processData(datetime.now().strftime(engine.DATE_FORMAT), isDeaths=True , days = days)
+    nations = engine.gatherData()
+    totalGraphRaw = engine.processData(nations,datetime.now().strftime(engine.DATE_FORMAT), days = days)
+    deathsGraphRaw = engine.processData(nations,datetime.now().strftime(engine.DATE_FORMAT), isDeaths=True , days = days)
 
     return render_template('index.html',
                            countries=totalGraphRaw['countries'].decode('ascii') ,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,10 +5,11 @@
 
       <h2>Country charts</h2>
       <a href="https://github.com/nocs85/corona_stats">nocs85/corona_stats</a>
-      {% if countries and deathsCountries %}
+      {% if countries and deathsCountries and deathsPopCountries %}
         <div>
           <img src="data:image/png;base64,{{ countries | safe }}" alt="Country chart alt" />
           <img src="data:image/png;base64,{{ deathsCountries | safe }}" alt="Country chart alt" />
+          <img src="data:image/png;base64,{{ deathsPopCountries | safe }}" alt="Country chart alt" />
         </div>
       {% else %}
         <p>Country chart unavailable - an error has occurred</p>
@@ -17,10 +18,11 @@
 
       <h2>Delay Charts</h2>
       <a href="https://github.com/nocs85/corona_stats">nocs85/corona_stats</a>
-      {% if delays and deathsDelays %}
+      {% if delays and deathsDelays and deathsPopDelays %}
         <div>
           <img src="data:image/png;base64,{{ delays | safe }}" alt="Delay chart alt" />
           <img src="data:image/png;base64,{{ deathsDelays | safe }}" alt="Delay chart alt" />
+          <img src="data:image/png;base64,{{ deathsPopDelays | safe }}" alt="Delay chart alt" />
         </div>
       {% else %}
         <p>Delay chart unavailable - an error has occurred</p>

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ if __name__ == "__main__":
     nations = engine.gatherData()
     engine.processData(nations, args.limitDate.strftime(engine.DATE_FORMAT))
     engine.processData(nations, args.limitDate.strftime(engine.DATE_FORMAT), isDeaths=True)
+    engine.processData(nations, args.limitDate.strftime(engine.DATE_FORMAT), isDeaths=True, isPopulation=True)
     # plot them
     plt.show()
 

--- a/main.py
+++ b/main.py
@@ -15,8 +15,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # generate graphs
-    engine.processData(args.limitDate.strftime(engine.DATE_FORMAT))
-    engine.processData(args.limitDate.strftime(engine.DATE_FORMAT),isDeaths=True)
+    nations = engine.gatherData()
+    engine.processData(nations, args.limitDate.strftime(engine.DATE_FORMAT))
+    engine.processData(nations, args.limitDate.strftime(engine.DATE_FORMAT), isDeaths=True)
     # plot them
     plt.show()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask
 python-dotenv
-requests
+grequests
+gevent
 matplotlib
 lxml

--- a/web.py
+++ b/web.py
@@ -1,1 +1,8 @@
+# The primary purpose of this module is to carefully patch, in place, portions
+# of the standard library with gevent-friendly functions that behave in the same
+# way as the original (at least as closely as possible).
+from gevent import monkey
+monkey.patch_all()
+
+# flask application import
 from app import app


### PR DESCRIPTION
- Decoupling crawling and plotting: fetch once all the webpages,
  then rinse and repeat data plotting.
- Replacing requests with erequests to allow event based 'parallel'
  data retrieval
- Naming and formatting
- removing days before min date after delay